### PR TITLE
[cask] Harden cask disk store for concurrent reads and writes

### DIFF
--- a/src/borkshop/cask/caskdiskstore/.cask/.gitignore
+++ b/src/borkshop/cask/caskdiskstore/.cask/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/borkshop/cask/caskdiskstore/stress_test.go
+++ b/src/borkshop/cask/caskdiskstore/stress_test.go
@@ -1,0 +1,29 @@
+package caskdiskstore
+
+import (
+	"borkshop/cask/casktest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/src-d/go-billy.v4/osfs"
+)
+
+func TestStress(t *testing.T) {
+	fs := osfs.New(".cask")
+	store := &Store{Filesystem: fs}
+	report := casktest.StressStoreConfig{
+		Concurrency: 100,
+		Duration:    200 * time.Millisecond,
+	}.Stress(store)
+
+	t.Logf("%d cycles\nn", report.Cycles)
+	t.Logf("%d write errors\n", report.WriteErrors)
+	t.Logf("%d read errors\n", report.ReadErrors)
+	t.Logf("%d data integrity errors\n", report.DataErrors)
+
+	assert.Equal(t, 0, report.WriteErrors, "write errors")
+	assert.Equal(t, 0, report.ReadErrors, "read errors")
+	assert.Equal(t, 0, report.DataErrors, "data integrity errors")
+	assert.NotEqual(t, 0, report.Cycles, "no cycles")
+}

--- a/src/borkshop/cask/casktest/stressstore.go
+++ b/src/borkshop/cask/casktest/stressstore.go
@@ -1,0 +1,85 @@
+package casktest
+
+import (
+	"borkshop/cask"
+	"borkshop/cask/caskblob"
+	"context"
+	"fmt"
+	"time"
+)
+
+const str = "Hello, CAS1KB!"
+
+type StressStoreReport struct {
+	Cycles      int
+	WriteErrors int
+	ReadErrors  int
+	DataErrors  int
+}
+
+func (r *StressStoreReport) merge(s *StressStoreReport) {
+	r.Cycles += s.Cycles
+	r.WriteErrors += s.WriteErrors
+	r.ReadErrors += s.ReadErrors
+	r.DataErrors += s.ReadErrors
+}
+
+type StressStoreConfig struct {
+	Concurrency int
+	Duration    time.Duration
+}
+
+func (c StressStoreConfig) Stress(store cask.Store) *StressStoreReport {
+	report := &StressStoreReport{}
+	done := make(chan struct{}, 0)
+	reports := make(chan *StressStoreReport, 0)
+
+	for i := 0; i < c.Concurrency; i++ {
+		go worker(done, reports, store)
+	}
+
+	time.Sleep(c.Duration)
+	close(done)
+
+	for i := 0; i < c.Concurrency; i++ {
+		report.merge(<-reports)
+	}
+	return report
+}
+
+func worker(done <-chan struct{}, reports chan<- *StressStoreReport, store cask.Store) {
+	report := &StressStoreReport{}
+	defer func() {
+		reports <- report
+	}()
+
+	ctx := context.Background()
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+
+		hash, err := caskblob.WriteString(ctx, store, str)
+		if err != nil {
+			fmt.Printf("%v\n", err)
+			report.WriteErrors++
+			continue
+		}
+
+		rst, err := caskblob.ReadString(ctx, store, hash)
+		if err != nil {
+			fmt.Printf("%v\n", err)
+			report.ReadErrors++
+			continue
+		}
+
+		if rst != str {
+			report.DataErrors++
+			continue
+		}
+
+		report.Cycles++
+	}
+}


### PR DESCRIPTION
This change introduces a stress test for concurrent reads and writes for the same block of data.

To address concurrency hazards, the disk store uses a retry loop for writes, whereby each worker races to create a "$LOC.partial" scratch space for their write, then uses an atomic rename to move the full block to "$LOC". Failing to get an exclusive lock on the scratch, the process yields to the OS, which should buy the other process just enough time to finish writing a single KB block to disk. The loser of the race then checks whether "$LOC" was written, since this is sufficient to guarantee that their job was already done by the other process and it’s safe to proceed reading the block for the given hash.