### PR TITLE
[cask] Add peer to peer support to cask CLI

### DIFF
--- a/src/borkshop/cask/cask/cask.go
+++ b/src/borkshop/cask/cask/cask.go
@@ -5,19 +5,43 @@ import (
 	"borkshop/cask/caskblob"
 	"borkshop/cask/caskdir"
 	"borkshop/cask/caskdiskstore"
+	"borkshop/cask/caskmemstore"
+	"borkshop/cask/casknet"
 	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
 
+	"go.uber.org/multierr"
 	"gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/osfs"
 )
+
+var usage = `Content Address Store of 1KB Blocks
+cask init [DIR]
+  Creates a .cask directory.
+  Other commands find the .cask directory in the first parent dir.
+cask store [HOST:PORT] < FILE > HASH
+  Stores input to CASK.
+  Writes the hash.
+cask load [HOST:PORT] HASH > FILE
+  Writes out the file for the given hash.
+cask checkin [HOST:PORT] DIR > HASH
+  Stores the given directory in CASK.
+  Writes the hash.
+cask checkout [HOST:PORT] DIR HASH
+  Writes out the directory tree from CASK to the given path.
+cask serve [HOST:PORT]
+  Runs a CASK server.
+  Commands sent with the server's address will use the server's .cask
+  instead of the local .cask.
+`
 
 func main() {
 	ctx := context.Background()
@@ -32,59 +56,108 @@ func main() {
 		cancel()
 	}()
 
-	if err := run(ctx, os.Args[1:], os.Stdout); err != nil {
+	if err := run(ctx, os.Args[1:], os.Stdout, os.Stderr); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err.Error())
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, args []string, stdout io.Writer) error {
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) (err error) {
 	if len(args) < 1 {
-		return fmt.Errorf("command name is a required argument")
+		fmt.Fprintf(stdout, usage)
+		return
 	}
 	command := args[0]
 
-	var hashArg string
-	var pathArg string
+	// Parse and validate arguments.
+	hashArg := ""
+	pathArg := "."
+	hostArg := ""
+	peerArg := ""
 	switch command {
+	case "help", "-h", "--help":
+		fmt.Fprintf(stdout, usage)
+		return
 	case "init":
 		switch len(args) {
 		case 1:
-			pathArg = "."
 		case 2:
 			pathArg = args[1]
 		default:
-			return fmt.Errorf("unexpected extra arguments: %v", args[2:])
+			err = fmt.Errorf("unexpected extra arguments: %v", args[2:])
+			return
 		}
 	case "store":
-		if len(args) != 1 {
-			return fmt.Errorf("unexpected extra arguments: %v", args[1:])
+		switch len(args) {
+		case 1:
+		case 2:
+			hostArg = "0:0"
+			peerArg = args[1]
+		default:
+			err = fmt.Errorf("unexpected extra arguments: %v", args[1:])
+			return
 		}
 	case "load":
-		if len(args) != 2 {
-			return fmt.Errorf("unexpected extra arguments: %v", args[2:])
+		switch len(args) {
+		case 2:
+			hashArg = args[1]
+		case 3:
+			hostArg = "0:0"
+			peerArg = args[1]
+			hashArg = args[2]
+		default:
+			err = fmt.Errorf("unexpected extra arguments: %v", args[2:])
+			return
 		}
-		hashArg = args[1]
 	case "checkin":
-		if len(args) != 2 {
-			return fmt.Errorf("unexpected extra arguments: %v", args[2:])
+		switch len(args) {
+		case 2:
+			pathArg = args[1]
+		case 3:
+			hostArg = "0:0"
+			peerArg = args[1]
+			pathArg = args[2]
+		default:
+			err = fmt.Errorf("unexpected extra arguments: %v", args[2:])
+			return
 		}
-		pathArg = args[1]
 	case "checkout":
-		if len(args) != 3 {
-			return fmt.Errorf("unexpected extra arguments: %v", args[3:])
+		switch len(args) {
+		case 3:
+			pathArg = args[1]
+			hashArg = args[2]
+		case 4:
+			hostArg = "0:0"
+			peerArg = args[1]
+			pathArg = args[2]
+			hashArg = args[3]
+		default:
+			err = fmt.Errorf("unexpected extra arguments: %v", args[3:])
+			return
 		}
-		pathArg = args[1]
-		hashArg = args[2]
+	case "serve":
+		switch len(args) {
+		case 1:
+			hostArg = "0:1024"
+		case 2:
+			hostArg = args[1]
+		default:
+			err = fmt.Errorf("unexpected extra arguments: %v", args[2:])
+			return
+		}
 	}
+
+	// Input and dependencies.
 
 	var hash cask.Hash
 	switch command {
 	case "load", "checkout":
-		if h, err := hex.DecodeString(hashArg); err != nil {
-			return err
+		if h, decodeErr := hex.DecodeString(hashArg); decodeErr != nil {
+			err = decodeErr
+			return
 		} else if len(h) != len(hash) {
-			return errors.New("invalid hash")
+			err = errors.New("invalid hash")
+			return
 		} else {
 			copy(hash[:], h)
 		}
@@ -93,8 +166,9 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	var path string
 	switch command {
 	case "checkin", "checkout":
-		if p, err := filepath.Abs(pathArg); err != nil {
-			return err
+		if p, absErr := filepath.Abs(pathArg); absErr != nil {
+			err = absErr
+			return
 		} else {
 			path = p
 		}
@@ -104,44 +178,86 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 
 	var store cask.Store
 	switch command {
-	case "store", "load", "checkin", "checkout":
-		if caskPath, err := findCask(fs); err != nil {
-			return err
+	case "store", "load", "checkin", "checkout", "serve":
+		if peerArg != "" {
+			store = caskmemstore.New()
 		} else {
-			fs := osfs.New(caskPath)
-			store = &caskdiskstore.Store{Filesystem: fs}
+			if caskPath, findErr := findCask(fs); findErr != nil {
+				err = findErr
+				return
+			} else {
+				fs := osfs.New(caskPath)
+				store = &caskdiskstore.Store{Filesystem: fs}
+			}
 		}
 	}
 
+	var server *casknet.Server
+	if hostArg != "" {
+		server = &casknet.Server{
+			Addr:  hostArg,
+			Store: store,
+		}
+		if startErr := server.Start(ctx); startErr != nil {
+			err = startErr
+			return
+		}
+		defer func() {
+			if stopErr := server.Stop(ctx); err != nil {
+				err = multierr.Append(err, stopErr)
+			}
+		}()
+	}
+
+	if peerArg != "" {
+		if udpAddr, resolveErr := net.ResolveUDPAddr("udp", peerArg); resolveErr != nil {
+			err = resolveErr
+		} else {
+			store = server.Peer(udpAddr)
+		}
+	}
+
+	// Execute.
 	switch command {
 	case "init":
-		if caskPath, err := filepath.Abs(filepath.Join(pathArg, ".cask")); err != nil {
-			return err
-		} else if err := fs.MkdirAll(caskPath, 755); err != nil {
-			return err
+		if caskPath, absErr := filepath.Abs(filepath.Join(pathArg, ".cask")); absErr != nil {
+			err = absErr
+			return
+		} else if mkdirErr := fs.MkdirAll(caskPath, 755); mkdirErr != nil {
+			err = mkdirErr
+			return
 		}
 	case "store":
-		if h, err := caskblob.Store(ctx, store, os.Stdin); err != nil {
-			return err
+		if h, storeErr := caskblob.Store(ctx, store, os.Stdin); storeErr != nil {
+			err = storeErr
+			return
 		} else {
 			hash = h
 		}
 	case "load":
-		if err := caskblob.Load(ctx, store, os.Stdout, hash); err != nil {
-			return err
+		if loadErr := caskblob.Load(ctx, store, os.Stdout, hash); loadErr != nil {
+			err = loadErr
+			return
 		}
 	case "checkin":
-		if h, err := caskdir.Store(ctx, store, fs, path); err != nil {
-			return err
+		if h, storeErr := caskdir.Store(ctx, store, fs, path); storeErr != nil {
+			err = storeErr
+			return
 		} else {
 			hash = h
 		}
 	case "checkout":
-		if err := caskdir.Load(ctx, store, fs, path, hash); err != nil {
-			return err
+		if loadErr := caskdir.Load(ctx, store, fs, path, hash); loadErr != nil {
+			err = loadErr
+			return
 		}
+	case "serve":
+		fmt.Fprintf(stderr, "Serving on %s\n", server.LocalAddr().String())
+		<-ctx.Done()
+		err = ctx.Err()
 	}
 
+	// Report.
 	switch command {
 	case "store", "checkin":
 		fmt.Fprintf(stdout, "%x\n", hash)


### PR DESCRIPTION
This change reärranges the existing command vocabulary for the cask command to include an optional peer to use as the CAS1KB store.

For my own amusement, I used 1024 as the default port. Get it?

To test:

In terminal A:

```
go install borkshop/cask/cask
cask init
cask serve
```

In terminal B:

```
echo hi | cask store 127.0.0.1:1024 | xargs cask load 127.0.0.1:1024
```

Checkin and checkout variants work as well if you want to move a directory tree over UDP.

You can return to terminal A and inspect the content of `.cask` and find your "hi" file in there.

The congestion avoidance and control flow are not yet implemented in casknet, so YMMV on the open internets.